### PR TITLE
Edit setup.py to point to correct line in README for project description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def extend_package(path):
         data_files.append(os.path.join("..", path))
 
 with open("README.md", encoding="utf-8") as fh:
-    readme_lines = fh.readlines()[2:]
+    readme_lines = fh.readlines()[4:]
 long_description = ("".join(readme_lines))
 
 extend_package(os.path.join(module_name, "notebooks"))


### PR DESCRIPTION
Simply edit the `readme_lines` start index to get the project description in setup.py.
This is needed after having added the image at the top of the readme, in case we update the package in the future. The issue does not affect current release 1.0 on PyPI